### PR TITLE
Replace dashes in identifiers

### DIFF
--- a/bundles/org.palladiosimulator.view.plantuml.generator/src/org/palladiosimulator/view/plantuml/generator/PcmComponentDiagramGenerator.java
+++ b/bundles/org.palladiosimulator.view.plantuml.generator/src/org/palladiosimulator/view/plantuml/generator/PcmComponentDiagramGenerator.java
@@ -413,6 +413,6 @@ public class PcmComponentDiagramGenerator {
 
     private static String escape(String identifier) {
         return identifier.replaceAll("\\s", ".")
-            .replaceAll("[/\\[\\]]", "_");
+            .replaceAll("[/\\[\\]-]", "_");
     }
 }


### PR DESCRIPTION
Leaving them in produces illegal PlantUML, e.g. for the [cwa-server](https://github.com/FloBoJa/ArDoCoBenchmark/tree/main/cwa-server) PCM repository.