### PR TITLE
Migrate to parent POM version 0.10.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.0</version>
+		<version>2.7.5</version>
 	</extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,9 +5,4 @@
 		<artifactId>tycho-build</artifactId>
 		<version>2.7.0</version>
 	</extension>
-	<extension>
-		<groupId>org.palladiosimulator</groupId>
-		<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
-		<version>0.2.6</version>
-	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.palladiosimulator</groupId>
         <artifactId>eclipse-parent-updatesite</artifactId>
-        <version>0.9.0</version>
+        <version>0.10.0</version>
     </parent>
 
     <groupId>org.palladiosimulator.view.plantuml</groupId>
@@ -18,7 +18,7 @@
 
 
     <properties>
-        <org.palladiosimulator.maven.tychotprefresh.tplocation.2>${project.basedir}/releng/org.palladiosimulator.view.plantuml.targetplatform/org.palladiosimulator.view.plantuml.targetplatform.target</org.palladiosimulator.maven.tychotprefresh.tplocation.2>
+        <targetPlatform.relativePath>releng/org.palladiosimulator.view.plantuml.targetplatform/tp.target</targetPlatform.relativePath>
     </properties>
 
     <modules>

--- a/releng/org.palladiosimulator.view.plantuml.targetplatform/org.palladiosimulator.view.plantuml.targetplatform.target
+++ b/releng/org.palladiosimulator.view.plantuml.targetplatform/org.palladiosimulator.view.plantuml.targetplatform.target
@@ -1,23 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?>
-<target name="Palladio Bench Plantuml Feature" sequenceNumber="1">
-    <locations>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" refresh="true">
-            <unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0" />
-            <unit id="de.uka.ipd.sdq.identifier.feature.source.feature.group" version="0.0.0" />
-            <unit id="org.palladiosimulator.commons.stoex.serialising.feature.feature.group" version="0.0.0" />
-            <unit id="org.palladiosimulator.commons.stoex.serialising.feature.source.feature.group" version="0.0.0" />
-            <repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/" />
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" refresh="true">
-            <unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0" />
-            <unit id="org.palladiosimulator.pcm.feature.source.feature.group" version="0.0.0" />
-            <repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/nightly/" />
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit" refresh="true">
-            <repository location="http://hallvard.github.io/plantuml/" />
-            <unit id="net.sourceforge.plantuml.ecore.feature.feature.group" version="0.0.0" />
-            <unit id="net.sourceforge.plantuml.ecore.feature.source.feature.group" version="0.0.0" />
-        </location>
-    </locations>
+<?pde version="3.8"?><target name="Palladio Bench Plantuml Feature" sequenceNumber="1">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" refresh="true">
+			<unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
+			<unit id="de.uka.ipd.sdq.identifier.feature.source.feature.group" version="0.0.0"/>
+			<unit id="org.palladiosimulator.commons.stoex.serialising.feature.feature.group" version="0.0.0"/>
+			<unit id="org.palladiosimulator.commons.stoex.serialising.feature.source.feature.group" version="0.0.0"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" refresh="true">
+			<unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0"/>
+			<unit id="org.palladiosimulator.pcm.feature.source.feature.group" version="0.0.0"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/nightly/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit" refresh="true">
+			<repository location="http://hallvard.github.io/plantuml/"/>
+			<unit id="net.sourceforge.plantuml.ecore.feature.feature.group" version="0.0.0"/>
+			<unit id="net.sourceforge.plantuml.ecore.feature.source.feature.group" version="0.0.0"/>
+		</location>
+	</locations>
 </target>

--- a/releng/org.palladiosimulator.view.plantuml.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.view.plantuml.targetplatform/tp.target
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="Palladio Bench Plantuml Feature" sequenceNumber="1">
+<?pde version="3.8"?><target name="Palladio Bench Plantuml Feature" sequenceNumber="2">
 	<locations>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" refresh="true">
+		<location type="Target" uri="mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03"/>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
 			<unit id="de.uka.ipd.sdq.identifier.feature.source.feature.group" version="0.0.0"/>
 			<unit id="org.palladiosimulator.commons.stoex.serialising.feature.feature.group" version="0.0.0"/>
 			<unit id="org.palladiosimulator.commons.stoex.serialising.feature.source.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" refresh="true">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0"/>
 			<unit id="org.palladiosimulator.pcm.feature.source.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/nightly/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit" refresh="true">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="http://hallvard.github.io/plantuml/"/>
 			<unit id="net.sourceforge.plantuml.ecore.feature.feature.group" version="0.0.0"/>
 			<unit id="net.sourceforge.plantuml.ecore.feature.source.feature.group" version="0.0.0"/>


### PR DESCRIPTION
### Overview
- Migrate from parent POM version `0.9.0` to the new parent POM version `0.10.0`
- Locally verified build success

### Changes
- In `pom.xml`:
  - Parent POM updated from `0.9.0` to `0.10.0`  
  - Renamed property `org.palladiosimulator.maven.tychotprefresh.tplocation.2` to `targetPlatform.relativePath` and trimmed its path value to start at `releng`  
- In `.mvn/extensions.xml`:
  - Removed `<extension>` block for `org.palladiosimulator:tycho-tp-refresh-maven-plugin`  
- In the target platform `org.palladiosimulator.view.plantuml.targetplatform.target`:
  - Inserted new `<location>` with URI `mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03`, since the Palladio target platform is now decoupled from the parent POM  
  - Unified all `includeSource` attributes by setting them to `false`, as the value must be the same across all locations to prevent resolution failure  
  - Removed specifics of the `tycho-tp-refresh-maven-plugin` to be standard-compliant:  
    - Removed any `<location filter="release">` entries  
    - Removed `filter="nightly"` attributes  
    - Removed all `refresh="true"` attributes and, where present, set each `<unit>`’s `version` attribute to `0.0.0`  
  - Added indentation to improve readability  
  - Renamed to the recommended name `tp.target`